### PR TITLE
only define  package 'rubygems' when not already defined.

### DIFF
--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -29,9 +29,11 @@ class datadog_agent::reports(
     }
   }
 
-  # Ensure rubygems is installed
-  class { 'ruby':
-    rubygems_update => false
+  if (! defined(Package['rubygems'])) {
+    # Ensure rubygems is installed
+    class { 'ruby':
+      rubygems_update => false
+    }
   }
 
   file { '/etc/dd-agent/datadog.yaml':


### PR DESCRIPTION
if class ruby is defined elsewhere, the datadog reports cannot be installed
